### PR TITLE
small, one-line  change to config file

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -11,7 +11,7 @@ module.exports = function(passport) {
   opts.secretOrKey = settings.secret;
   passport.use(
     new JwtStrategy(opts, function(jwt_payload, done) {
-      User.findOne({ id: jwt_payload.id }, function(err, user) {
+      User.findOne({ _id: jwt_payload._id }, function(err, user) {
         if (err) {
           return done(err, false);
         }


### PR DESCRIPTION
In the comments of the article I used to study authentication, I noticed that it was recommended to change one line of the the authentication code to avoid problems that could possibly arise when multiple users are on the site. (I didn't see it myself when logged onto the site with two different ids on two different browsers.  

No harm in making it though.   Done.  No change noticed. 